### PR TITLE
[mono-api-info] Added a config option to allow resolution errors to be skipped

### DIFF
--- a/mcs/tools/corcompare/Util.cs
+++ b/mcs/tools/corcompare/Util.cs
@@ -101,6 +101,18 @@ namespace Mono.ApiTools {
 			}
 		}
 
+		internal MethodDefinition GetMethod (MethodReference method)
+		{
+			if (method == null)
+				throw new ArgumentNullException (nameof (method));
+
+			try {
+				return method.Resolve ();
+			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
+				return null;
+			}
+		}
+
 		internal bool IsPublic (CustomAttribute att)
 		{
 			return IsPublic (att.AttributeType);

--- a/mcs/tools/corcompare/Util.cs
+++ b/mcs/tools/corcompare/Util.cs
@@ -16,6 +16,19 @@ namespace Mono.ApiTools {
 
 		public AssemblyResolver Resolver { get; } = new AssemblyResolver();
 
+		internal bool TryResolve (CustomAttribute attribute)
+		{
+			if (attribute == null)
+				throw new ArgumentNullException (nameof (attribute));
+
+			try {
+				var has = attribute.HasProperties;
+				return true;
+			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
+				return false;
+			}
+		}
+
 		internal bool IsPublic (TypeReference typeref)
 		{
 			if (typeref == null)
@@ -77,18 +90,6 @@ namespace Mono.ApiTools {
 
 			try {
 				return child.BaseType.Resolve ();
-			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
-				return null;
-			}
-		}
-
-		internal MethodDefinition GetMethod (MethodReference method)
-		{
-			if (method == null)
-				throw new ArgumentNullException (nameof (method));
-
-			try {
-				return method.Resolve ();
 			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
 				return null;
 			}

--- a/mcs/tools/corcompare/Util.cs
+++ b/mcs/tools/corcompare/Util.cs
@@ -42,7 +42,7 @@ namespace Mono.ApiTools {
 				if (td == null)
 					return false;
 
-				return td.IsPublic;
+				return td.IsPublic || (td.IsNestedPublic && IsPublic (td.DeclaringType));
 			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
 				return true;
 			}

--- a/mcs/tools/corcompare/Util.cs
+++ b/mcs/tools/corcompare/Util.cs
@@ -7,6 +7,13 @@ namespace Mono.ApiTools {
 
 	class TypeHelper {
 
+		public TypeHelper (bool ignoreResolutionErrors)
+		{
+			IgnoreResolutionErrors = ignoreResolutionErrors;
+		}
+
+		public bool IgnoreResolutionErrors { get; }
+
 		public AssemblyResolver Resolver { get; } = new AssemblyResolver();
 
 		internal bool IsPublic (TypeReference typeref)
@@ -14,11 +21,15 @@ namespace Mono.ApiTools {
 			if (typeref == null)
 				throw new ArgumentNullException ("typeref");
 
-			TypeDefinition td = typeref.Resolve ();
-			if (td == null)
-				return false;
+			try {
+				var td = typeref.Resolve ();
+				if (td == null)
+					return false;
 
-			return td.IsPublic;
+				return td.IsPublic;
+			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
+				return true;
+			}
 		}
 
 		internal bool IsDelegate (TypeReference typeref)
@@ -64,7 +75,23 @@ namespace Mono.ApiTools {
 			if (child.BaseType == null)
 				return null;
 
-			return child.BaseType.Resolve ();
+			try {
+				return child.BaseType.Resolve ();
+			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
+				return null;
+			}
+		}
+
+		internal MethodDefinition GetMethod (MethodReference method)
+		{
+			if (method == null)
+				throw new ArgumentNullException (nameof (method));
+
+			try {
+				return method.Resolve ();
+			} catch (AssemblyResolutionException) when (IgnoreResolutionErrors) {
+				return null;
+			}
 		}
 
 		internal bool IsPublic (CustomAttribute att)

--- a/mcs/tools/corcompare/Util.cs
+++ b/mcs/tools/corcompare/Util.cs
@@ -7,12 +7,15 @@ namespace Mono.ApiTools {
 
 	class TypeHelper {
 
-		public TypeHelper (bool ignoreResolutionErrors)
+		public TypeHelper (bool ignoreResolutionErrors, bool ignoreInheritedInterfaces)
 		{
 			IgnoreResolutionErrors = ignoreResolutionErrors;
+			IgnoreInheritedInterfaces = ignoreInheritedInterfaces;
 		}
 
 		public bool IgnoreResolutionErrors { get; }
+
+		public bool IgnoreInheritedInterfaces { get; }
 
 		public AssemblyResolver Resolver { get; } = new AssemblyResolver();
 
@@ -76,9 +79,12 @@ namespace Mono.ApiTools {
 		{
 			var ifaces = new Dictionary<string, TypeReference> ();
 
-			foreach (var def in WalkHierarchy (type))
+			foreach (var def in WalkHierarchy (type)) {
 				foreach (var iface in def.Interfaces)
 					ifaces [iface.InterfaceType.FullName] = iface.InterfaceType;
+				if (IgnoreInheritedInterfaces)
+					break;
+			}
 
 			return ifaces.Values;
 		}

--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -102,6 +102,8 @@ namespace Mono.ApiTools {
 
 		public bool FullApiSet { get; set; } = false;
 
+		public bool IgnoreResolutionErrors { get; set; } = false;
+
 		public List<string> SearchDirectories { get; } = new List<string> ();
 
 		public List<string> ResolveFiles { get; } = new List<string> ();
@@ -112,7 +114,7 @@ namespace Mono.ApiTools {
 
 		public void ResolveTypes ()
 		{
-			TypeHelper = new TypeHelper ();
+			TypeHelper = new TypeHelper (IgnoreResolutionErrors);
 
 			if (SearchDirectories != null) {
 				foreach (var v in SearchDirectories)
@@ -136,6 +138,8 @@ namespace Mono.ApiTools {
 		public bool FollowForwarders { get; set; } = false;
 
 		public bool FullApiSet { get; set; } = false;
+
+		public bool IgnoreResolutionErrors { get; set; } = false;
 
 		public List<string> SearchDirectories { get; set; } = new List<string> ();
 
@@ -184,6 +188,7 @@ namespace Mono.ApiTools {
 				AbiMode = config.AbiMode,
 				FollowForwarders = config.FollowForwarders,
 				FullApiSet = config.FullApiSet,
+				IgnoreResolutionErrors = config.IgnoreResolutionErrors,
 			};
 			state.SearchDirectories.AddRange (config.SearchDirectories);
 			state.ResolveFiles.AddRange (config.ResolveFiles);
@@ -1390,13 +1395,13 @@ namespace Mono.ApiTools {
 			writer.WriteEndElement (); // attributes
 		}
 
-		static Dictionary<string, object> CreateAttributeMapping (CustomAttribute attribute)
+		Dictionary<string, object> CreateAttributeMapping (CustomAttribute attribute)
 		{
 			Dictionary<string, object> mapping = null;
 
 			PopulateMapping (ref mapping, attribute);
 
-			var constructor = attribute.Constructor.Resolve ();
+			var constructor = state.TypeHelper.GetMethod (attribute.Constructor);
 			if (constructor == null || !constructor.HasParameters)
 				return mapping;
 

--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -1409,7 +1409,7 @@ namespace Mono.ApiTools {
 
 			PopulateMapping (ref mapping, attribute);
 
-			var constructor = attribute.Constructor.Resolve ();
+			var constructor = state.TypeHelper.GetMethod (attribute.Constructor);
 			if (constructor == null || !constructor.HasParameters)
 				return mapping;
 

--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -839,7 +839,7 @@ namespace Mono.ApiTools {
 		}
 
 
-		internal static PropertyDefinition [] GetProperties (TypeDefinition type, bool fullAPI) {
+		internal PropertyDefinition [] GetProperties (TypeDefinition type, bool fullAPI) {
 			var list = new List<PropertyDefinition> ();
 
 			var t = type;
@@ -872,7 +872,7 @@ namespace Mono.ApiTools {
 				if (t.BaseType == null || t.BaseType.FullName == "System.Object")
 					t = null;
 				else
-					t = t.BaseType.Resolve ();
+					t = state.TypeHelper.GetBaseType (t);
 
 			} while (t != null);
 
@@ -919,7 +919,7 @@ namespace Mono.ApiTools {
 				if (t.BaseType == null || t.BaseType.FullName == "System.Object")
 					t = null;
 				else
-					t = t.BaseType.Resolve ();
+					t = state.TypeHelper.GetBaseType (t);
 
 			} while (t != null);
 

--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -1399,9 +1399,12 @@ namespace Mono.ApiTools {
 		{
 			Dictionary<string, object> mapping = null;
 
+			if (!state.TypeHelper.TryResolve (attribute))
+				return mapping;
+
 			PopulateMapping (ref mapping, attribute);
 
-			var constructor = state.TypeHelper.GetMethod (attribute.Constructor);
+			var constructor = attribute.Constructor.Resolve ();
 			if (constructor == null || !constructor.HasParameters)
 				return mapping;
 

--- a/mcs/tools/corcompare/mono-api-info.cs
+++ b/mcs/tools/corcompare/mono-api-info.cs
@@ -104,6 +104,8 @@ namespace Mono.ApiTools {
 
 		public bool IgnoreResolutionErrors { get; set; } = false;
 
+		public bool IgnoreInheritedInterfaces { get; set; } = false;
+
 		public List<string> SearchDirectories { get; } = new List<string> ();
 
 		public List<string> ResolveFiles { get; } = new List<string> ();
@@ -114,7 +116,7 @@ namespace Mono.ApiTools {
 
 		public void ResolveTypes ()
 		{
-			TypeHelper = new TypeHelper (IgnoreResolutionErrors);
+			TypeHelper = new TypeHelper (IgnoreResolutionErrors, IgnoreInheritedInterfaces);
 
 			if (SearchDirectories != null) {
 				foreach (var v in SearchDirectories)
@@ -140,6 +142,8 @@ namespace Mono.ApiTools {
 		public bool FullApiSet { get; set; } = false;
 
 		public bool IgnoreResolutionErrors { get; set; } = false;
+
+		public bool IgnoreInheritedInterfaces { get; set; } = false;
 
 		public List<string> SearchDirectories { get; set; } = new List<string> ();
 
@@ -189,6 +193,7 @@ namespace Mono.ApiTools {
 				FollowForwarders = config.FollowForwarders,
 				FullApiSet = config.FullApiSet,
 				IgnoreResolutionErrors = config.IgnoreResolutionErrors,
+				IgnoreInheritedInterfaces = config.IgnoreInheritedInterfaces,
 			};
 			state.SearchDirectories.AddRange (config.SearchDirectories);
 			state.ResolveFiles.AddRange (config.ResolveFiles);


### PR DESCRIPTION
This is nice when we don't care where the base type is located, just that it has/hasn't changed (the full name is just fine)

A potential use case is that I just built a NuGet/library and I want to compare my current API with the previous API. All I care about is that the types haven't changed their base type.

This is hopefully going to be part of https://github.com/mono/mono/pull/9793